### PR TITLE
Add support for var arrays

### DIFF
--- a/examples/multiple-translations/README.md
+++ b/examples/multiple-translations/README.md
@@ -1,0 +1,11 @@
+To get started, set your OPENAI_API_KEY environment variable.
+
+Next, change a few of the prompts in prompts.txt and edit promptfooconfig.yaml.
+
+Then run:
+
+```
+promptfoo eval
+```
+
+Afterwards, you can view the results by running `promptfoo view`

--- a/examples/multiple-translations/promptfooconfig.yaml
+++ b/examples/multiple-translations/promptfooconfig.yaml
@@ -1,0 +1,10 @@
+prompts: prompts.txt
+providers: [openai:gpt-3.5-turbo, openai:gpt-4]
+tests:
+  - vars:
+      language: [French, German, Spanish]
+      input: ['Hello world', 'Good morning', 'How are you?']
+    assert:
+      - type: similar
+        value: 'Hello world'
+        threshold: 0.8

--- a/examples/multiple-translations/prompts.txt
+++ b/examples/multiple-translations/prompts.txt
@@ -1,0 +1,3 @@
+You're a translator.  Translate this into {{language}}: {{input}}
+---
+Speak in {{language}}: {{input}}

--- a/examples/simple-test/output.csv
+++ b/examples/simple-test/output.csv
@@ -5,9 +5,7 @@ Aye.","[FAIL] Expected output ""Yarr""
 ---
 , me hearties! We be sailin' the high seas in search of treasure and adventure! Hoist the Jolly Roger and let's set sail! Arrrrr!",Yes
 "[PASS] I be feelin' a mighty need for grub, matey.","[PASS] Arrr, me belly be rumblin'! I be needin' some grub, mateys! Bring me some vittles or ye'll be walkin' the plank!",I'm hungry
-"[FAIL] API response error: TypeError: Cannot read properties of undefined (reading '0'): {""error"":{""message"":""That model is currently overloaded with other requests. You can retry your request, or contact us through our help center at help.openai.com if the error persists. (Please include the request ID 5102a6ce396f450a664c71fc906e6e09 in your message.)"",""type"":""server_error"",""param"":null,""code"":null}}
----
-API response error: TypeError: Cannot read properties of undefined (reading '0'): {""error"":{""message"":""That model is currently overloaded with other requests. You can retry your request, or contact us through our help center at help.openai.com if the error persists. (Please include the request ID 5102a6ce396f450a664c71fc906e6e09 in your message.)"",""type"":""server_error"",""param"":null,""code"":null}}","[PASS] {
+"[PASS] ""Spew forth the tale of yer life in JSON, me hearty!""","[PASS] {
   ""name"": ""Captain Blackbeard"",
   ""age"": 45,
   ""occupation"": ""Pirate"",
@@ -80,11 +78,7 @@ API response error: TypeError: Cannot read properties of undefined (reading '0')
     }
   ]
 }",Output the story of your life in JSON
-"[FAIL] Error: Invariant failed: Similarity assertion must have a threshold
----
-Error: Invariant failed: Similarity assertion must have a threshold","[FAIL] Error: Invariant failed: Similarity assertion must have a threshold
----
-Error: Invariant failed: Similarity assertion must have a threshold",Hello world
+[PASS] Ahoy mateys o' the world!,"[PASS] Ahoy there, me hearties! Avast ye landlubbers! 'Tis I, a fearsome pirate, comin' to ye from the seven seas. Ahoy, hello world!",Hello world
 "[FAIL] Error: Unknown assertion type: undefined
 ---
 Error: Unknown assertion type: undefined","[FAIL] Error: Unknown assertion type: undefined

--- a/examples/simple-test/promptfooconfig.yaml
+++ b/examples/simple-test/promptfooconfig.yaml
@@ -50,4 +50,3 @@ assertionTemplates:
   containsPirateNoise:
     type: javascript
     value: output.toLowerCase().includes('arrr')
-

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -6,13 +6,13 @@ import { cosineSimilarity } from './util.js';
 import { loadApiProvider } from './providers.js';
 import { DEFAULT_GRADING_PROMPT } from './prompts.js';
 
-import type { Assertion, GradingConfig, TestCase, GradingResult } from './types.js';
+import type { Assertion, GradingConfig, TestCase, GradingResult, AtomicTestCase } from './types.js';
 
 const SIMILAR_REGEX = /similar(?::|\((\d+(\.\d+)?)\):)/;
 
 const DEFAULT_SEMANTIC_SIMILARITY_THRESHOLD = 0.8;
 
-export async function runAssertions(test: TestCase, output: string): Promise<GradingResult> {
+export async function runAssertions(test: AtomicTestCase, output: string): Promise<GradingResult> {
   const tokensUsed = {
     total: 0,
     prompt: 0,
@@ -41,7 +41,7 @@ export async function runAssertions(test: TestCase, output: string): Promise<Gra
 
 export async function runAssertion(
   assertion: Assertion,
-  test: TestCase,
+  test: AtomicTestCase,
   output: string,
 ): Promise<GradingResult> {
   let pass: boolean = false;

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -22,7 +22,8 @@ const cacheType =
 
 function getCache() {
   if (!cacheInstance) {
-    const cachePath = process.env.PROMPTFOO_CACHE_PATH || path.join(getConfigDirectoryPath(), 'cache');
+    const cachePath =
+      process.env.PROMPTFOO_CACHE_PATH || path.join(getConfigDirectoryPath(), 'cache');
     if (!fs.existsSync(cachePath)) {
       logger.info(`Creating cache folder at ${cachePath}.`);
       fs.mkdirSync(cachePath, { recursive: true });

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -18,6 +18,7 @@ import type {
   TestSuite,
   Prompt,
   TestCase,
+  AtomicTestCase,
 } from './types.js';
 import { generatePrompts } from './suggestions.js';
 
@@ -25,7 +26,7 @@ interface RunEvalOptions {
   provider: ApiProvider;
   prompt: string;
 
-  test: TestCase;
+  test: AtomicTestCase;
 
   includeProviderId?: boolean;
 
@@ -34,6 +35,29 @@ interface RunEvalOptions {
 }
 
 const DEFAULT_MAX_CONCURRENCY = 4;
+
+function generateVarCombinations(
+  vars: Record<string, string | string[]>,
+): Record<string, string>[] {
+  const keys = Object.keys(vars);
+  const combinations: Record<string, string>[] = [{}];
+
+  for (const key of keys) {
+    const values = Array.isArray(vars[key]) ? vars[key] : [vars[key]];
+    const newCombinations: Record<string, string>[] = [];
+
+    for (const combination of combinations) {
+      for (const value of values) {
+        newCombinations.push({ ...combination, [key]: value as string });
+      }
+    }
+
+    combinations.length = 0;
+    combinations.push(...newCombinations);
+  }
+
+  return combinations;
+}
 
 class Evaluator {
   testSuite: TestSuite;
@@ -197,10 +221,10 @@ class Evaluator {
     });
 
     const varNames: Set<string> = new Set();
-    const varsWithSpecialColsRemoved: Record<string, string>[] = [];
+    const varsWithSpecialColsRemoved: Record<string, string | string[]>[] = [];
     for (const testCase of tests) {
       if (testCase.vars) {
-        const varWithSpecialColsRemoved: Record<string, string> = {};
+        const varWithSpecialColsRemoved: Record<string, string | string[]> = {};
         for (const varName of Object.keys(testCase.vars)) {
           varNames.add(varName);
           varWithSpecialColsRemoved[varName] = testCase.vars[varName];
@@ -245,8 +269,6 @@ class Evaluator {
     const runEvalOptions: RunEvalOptions[] = [];
     let rowIndex = 0;
     for (const testCase of tests) {
-      let colIndex = 0;
-
       // Handle default properties
       testCase.vars = Object.assign({}, testSuite.defaultTest?.vars, testCase.vars);
       testCase.assert = [...(testSuite.defaultTest?.assert || []), ...(testCase.assert || [])];
@@ -259,20 +281,24 @@ class Evaluator {
         testCase.options?.suffix || testSuite.defaultTest?.options?.suffix || '';
 
       // Finalize test case eval
-      for (const promptContent of testSuite.prompts) {
-        for (const provider of testSuite.providers) {
-          runEvalOptions.push({
-            provider,
-            prompt: prependToPrompt + promptContent + appendToPrompt,
-            test: testCase,
-            includeProviderId: testSuite.providers.length > 1,
-            rowIndex,
-            colIndex,
-          });
-          colIndex++;
+      const varCombinations = generateVarCombinations(testCase.vars || {});
+      for (const vars of varCombinations) {
+        let colIndex = 0;
+        for (const promptContent of testSuite.prompts) {
+          for (const provider of testSuite.providers) {
+            runEvalOptions.push({
+              provider,
+              prompt: prependToPrompt + promptContent + appendToPrompt,
+              test: { ...testCase, vars },
+              includeProviderId: testSuite.providers.length > 1,
+              rowIndex,
+              colIndex,
+            });
+            colIndex++;
+          }
         }
+        rowIndex++;
       }
-      rowIndex++;
     }
 
     // Actually run the eval
@@ -320,7 +346,7 @@ class Evaluator {
         if (!table.body[rowIndex]) {
           table.body[rowIndex] = {
             outputs: [],
-            vars: table.head.vars.map((varName) => options.test.vars?.[varName] || ''),
+            vars: table.head.vars.map((varName) => options.test.vars?.[varName] || '').flat(),
           };
         }
         table.body[rowIndex].outputs[colIndex] = resultText;

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,9 +52,7 @@ function createDummyFiles(directory: string | null) {
   writeFileSync(pathJoin(process.cwd(), directory, 'README.md'), DEFAULT_README);
 
   if (directory === '.') {
-    logger.info(
-      'Wrote prompts.txt and promptfooconfig.js. Open README.md to get started!',
-    );
+    logger.info('Wrote prompts.txt and promptfooconfig.js. Open README.md to get started!');
   } else {
     logger.info(`Wrote prompts.txt and promptfooconfig.js to ./${directory}`);
     logger.info(`\`cd ${directory}\` and open README.md to get started!`);
@@ -128,11 +126,7 @@ async function main() {
       'Path to CSV with test cases',
       config?.commandLineOptions?.vars,
     )
-    .option(
-      '-t, --tests <path>',
-      'Path to CSV with test cases',
-      config?.commandLineOptions?.tests,
-    )
+    .option('-t, --tests <path>', 'Path to CSV with test cases', config?.commandLineOptions?.tests)
     .option('-o, --output <path>', 'Path to output file (csv, json, yaml, html)', config.outputPath)
     .option(
       '-j, --max-concurrency <number>',

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,13 +134,18 @@ export interface TestCase {
   description?: string;
 
   // Key-value pairs to substitute in the prompt
-  vars?: Record<string, string>;
+  vars?: Record<string, string | string[]>;
 
   // Optional list of automatic checks to run on the LLM output
   assert?: Assertion[];
 
   // Additional configuration settings for the prompt
   options?: PromptConfig & GradingConfig;
+}
+
+// Same as a TestCase, except the `vars` object has been flattened into its final form.
+export interface AtomicTestCase extends TestCase {
+  vars?: Record<string, string>;
 }
 
 // The test suite defines the "knobs" that we are tuning in prompt engineering: providers and prompts

--- a/src/util.ts
+++ b/src/util.ts
@@ -15,13 +15,7 @@ import { getDirectory } from './esm.js';
 
 import type { RequestInfo, RequestInit, Response } from 'node-fetch';
 
-import type {
-  Assertion,
-  CsvRow,
-  EvaluateSummary,
-  UnifiedConfig,
-  TestCase,
-} from './types.js';
+import type { Assertion, CsvRow, EvaluateSummary, UnifiedConfig, TestCase } from './types.js';
 import { assertionFromString } from './assertions.js';
 
 const PROMPT_DELIMITER = '---';

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -9,6 +9,7 @@ import { DefaultEmbeddingProvider } from '../src/providers/openai';
 import type {
   Assertion,
   ApiProvider,
+  AtomicTestCase,
   TestCase,
   GradingConfig,
   ProviderResponse,
@@ -16,7 +17,7 @@ import type {
 } from '../src/types';
 
 describe('runAssertions', () => {
-  const test: TestCase = {
+  const test: AtomicTestCase = {
     assert: [
       {
         type: 'equals',
@@ -64,7 +65,11 @@ describe('runAssertion', () => {
   it('should pass when the equality assertion passes', async () => {
     const output = 'Expected output';
 
-    const result: GradingResult = await runAssertion(equalityAssertion, {} as TestCase, output);
+    const result: GradingResult = await runAssertion(
+      equalityAssertion,
+      {} as AtomicTestCase,
+      output,
+    );
     expect(result.pass).toBeTruthy();
     expect(result.reason).toBe('Assertion passed');
   });
@@ -72,7 +77,11 @@ describe('runAssertion', () => {
   it('should fail when the equality assertion fails', async () => {
     const output = 'Different output';
 
-    const result: GradingResult = await runAssertion(equalityAssertion, {} as TestCase, output);
+    const result: GradingResult = await runAssertion(
+      equalityAssertion,
+      {} as AtomicTestCase,
+      output,
+    );
     expect(result.pass).toBeFalsy();
     expect(result.reason).toBe('Expected output "Expected output"');
   });
@@ -80,7 +89,7 @@ describe('runAssertion', () => {
   it('should pass when the is-json assertion passes', async () => {
     const output = '{"key": "value"}';
 
-    const result: GradingResult = await runAssertion(isJsonAssertion, {} as TestCase, output);
+    const result: GradingResult = await runAssertion(isJsonAssertion, {} as AtomicTestCase, output);
     expect(result.pass).toBeTruthy();
     expect(result.reason).toBe('Assertion passed');
   });
@@ -88,7 +97,7 @@ describe('runAssertion', () => {
   it('should fail when the is-json assertion fails', async () => {
     const output = 'Not valid JSON';
 
-    const result: GradingResult = await runAssertion(isJsonAssertion, {} as TestCase, output);
+    const result: GradingResult = await runAssertion(isJsonAssertion, {} as AtomicTestCase, output);
     expect(result.pass).toBeFalsy();
     expect(result.reason).toContain('Expected output to be valid JSON');
   });
@@ -97,7 +106,11 @@ describe('runAssertion', () => {
     const output =
       'this is some other stuff \n\n {"key": "value", "key2": {"key3": "value2", "key4": ["value3", "value4"]}} \n\n blah blah';
 
-    const result: GradingResult = await runAssertion(containsJsonAssertion, {} as TestCase, output);
+    const result: GradingResult = await runAssertion(
+      containsJsonAssertion,
+      {} as AtomicTestCase,
+      output,
+    );
     expect(result.pass).toBeTruthy();
     expect(result.reason).toBe('Assertion passed');
   });
@@ -105,7 +118,11 @@ describe('runAssertion', () => {
   it('should fail when the contains-json assertion fails', async () => {
     const output = 'Not valid JSON';
 
-    const result: GradingResult = await runAssertion(containsJsonAssertion, {} as TestCase, output);
+    const result: GradingResult = await runAssertion(
+      containsJsonAssertion,
+      {} as AtomicTestCase,
+      output,
+    );
     expect(result.pass).toBeFalsy();
     expect(result.reason).toContain('Expected output to contain valid JSON');
   });
@@ -113,7 +130,11 @@ describe('runAssertion', () => {
   it('should pass when the function assertion passes', async () => {
     const output = 'Expected output';
 
-    const result: GradingResult = await runAssertion(functionAssertion, {} as TestCase, output);
+    const result: GradingResult = await runAssertion(
+      functionAssertion,
+      {} as AtomicTestCase,
+      output,
+    );
     expect(result.pass).toBeTruthy();
     expect(result.reason).toBe('Assertion passed');
   });
@@ -121,7 +142,11 @@ describe('runAssertion', () => {
   it('should fail when the function assertion fails', async () => {
     const output = 'Different output';
 
-    const result: GradingResult = await runAssertion(functionAssertion, {} as TestCase, output);
+    const result: GradingResult = await runAssertion(
+      functionAssertion,
+      {} as AtomicTestCase,
+      output,
+    );
     expect(result.pass).toBeFalsy();
     expect(result.reason).toBe('Custom function returned false');
   });

--- a/test/evaluator.test.ts
+++ b/test/evaluator.test.ts
@@ -58,6 +58,28 @@ describe('evaluator', () => {
     expect(summary.results[0].response?.output).toBe('Test output');
   });
 
+  test('evaluate with multiple vars', async () => {
+    const testSuite: TestSuite = {
+      providers: [mockApiProvider],
+      prompts: ['Test prompt {{ var1 }} {{ var2 }}'],
+      tests: [
+        {
+          vars: { var1: ['value1', 'value3'], var2: ['value2', 'value4'] },
+        },
+      ],
+    };
+
+    const summary = await evaluate(testSuite, {});
+
+    expect(mockApiProvider.callApi).toHaveBeenCalledTimes(4);
+    expect(summary.stats.successes).toBe(4);
+    expect(summary.stats.failures).toBe(0);
+    expect(summary.stats.tokenUsage).toEqual({ total: 40, prompt: 20, completion: 20, cached: 0 });
+    expect(summary.results[0].prompt.raw).toBe('Test prompt value1 value2');
+    expect(summary.results[0].prompt.display).toBe('Test prompt {{ var1 }} {{ var2 }}');
+    expect(summary.results[0].response?.output).toBe('Test output');
+  });
+
   test('evaluate with multiple providers', async () => {
     const testSuite: TestSuite = {
       providers: [mockApiProvider, mockApiProvider],

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -250,7 +250,9 @@ describe('readTests', () => {
   });
 
   test('readTests with string input (CSV file path)', async () => {
-    (fs.readFileSync as jest.Mock).mockReturnValue('var1,var2,__expected\nvalue1,value2,value1\nvalue3,value4,fn:value5');
+    (fs.readFileSync as jest.Mock).mockReturnValue(
+      'var1,var2,__expected\nvalue1,value2,value1\nvalue3,value4,fn:value5',
+    );
     const testsPath = 'tests.csv';
 
     const result = await readTests(testsPath);


### PR DESCRIPTION
This allows `vars` values to be arrays.  The test case runs each combination of the values.

Example config:
```yaml
prompts: prompts.txt
providers: [openai:gpt-3.5-turbo, openai:gpt-4]
tests:
  - vars:
      language: [French, German, Spanish]
      input: ['Hello world', 'Good morning', 'How are you?']
    assert:
      - type: similar
        value: 'Hello world'
        threshold: 0.8
```

Results in evaluation of each `language` x `input` combination

<img width="1100" alt="image" src="https://github.com/typpo/promptfoo/assets/310310/dab27ca5-689b-4843-bb52-de8d459d783b">
