### PR TITLE
chore: add jest as dev package

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/nunjucks": "^3.2.2",
     "@types/opener": "^1.4.0",
     "babel-jest": "^29.5.0",
+    "jest": "^29.5.0",
     "jest-watch-typeahead": "^2.2.2",
     "prettier": "^2.8.8",
     "ts-jest": "^29.1.0",


### PR DESCRIPTION
I was surprised there's a script: "test": "jest", but no jest installed. I guess you had it installed globally.