### PR TITLE
Add support for named prompts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,14 @@ interface EvaluateTestSuite extends TestSuiteConfig {
 async function evaluate(testSuite: EvaluateTestSuite, options: EvaluateOptions = {}) {
   const constructedTestSuite: TestSuite = {
     ...testSuite,
-    prompts: testSuite.prompts, // raw prompts expected
     providers: await loadApiProviders(testSuite.providers),
     tests: await readTests(testSuite.tests),
+
+    // Full prompts expected (not filepaths)
+    prompts: testSuite.prompts.map((promptContent) => ({
+      raw: promptContent,
+      display: promptContent,
+    })),
   };
   return doEvaluate(constructedTestSuite, options);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,7 +157,7 @@ export interface TestSuite {
   providers: ApiProvider[];
 
   // One or more prompt strings
-  prompts: string[];
+  prompts: Prompt[];
 
   // Test cases
   tests?: TestCase[];


### PR DESCRIPTION
- When a prompt is large (> 250 chars), display its filepath in column headers instead of full prompt text
- Support naming of prompts in yaml.  Example:
  ```yaml
  prompts:
    path/to/prompt1.txt: My First Prompt
    path/to/prompt2.txt: My Second Prompt
  ```