### PR TITLE
fix parsing of env vars for OPENAI_MAX_TOKENS and OPENAI_MAX_TEMPERATURE

### DIFF
--- a/src/providers/openai.ts
+++ b/src/providers/openai.ts
@@ -137,8 +137,8 @@ export class OpenAiCompletionProvider extends OpenAiGenericProvider {
     const body = {
       model: this.modelName,
       prompt,
-      max_tokens: process.env.OPENAI_MAX_TOKENS || 1024,
-      temperature: options?.temperature ?? (process.env.OPENAI_MAX_TEMPERATURE || 0),
+      max_tokens: parseInt(process.env.OPENAI_MAX_TOKENS || '1024'),
+      temperature: options?.temperature ?? parseFloat(process.env.OPENAI_MAX_TEMPERATURE || '0'),
       stop,
     };
     logger.debug(`Calling OpenAI API: ${JSON.stringify(body)}`);
@@ -218,8 +218,8 @@ export class OpenAiChatCompletionProvider extends OpenAiGenericProvider {
     const body = {
       model: this.modelName,
       messages: messages,
-      max_tokens: process.env.OPENAI_MAX_TOKENS || 1024,
-      temperature: options?.temperature ?? (process.env.OPENAI_MAX_TEMPERATURE || 0),
+      max_tokens: parseInt(process.env.OPENAI_MAX_TOKENS || '1024'),
+      temperature: options?.temperature ?? parseFloat(process.env.OPENAI_MAX_TEMPERATURE || '0'),
     };
     logger.debug(`Calling OpenAI API: ${JSON.stringify(body)}`);
 


### PR DESCRIPTION
I was running into API responses when I set OPENAI_MAX_TEMPERATURE since it gets read in as a string:

```
 [FAIL] API response error:           │ Recipe App                           │ \- type of meat                      │
│ TypeError: Cannot read properties of │                                      │                                      │
│  undefined (reading '0'): {"error":{ │                                      │                                      │
│ "message":"'1' is not of type 'numbe │                                      │                                      │
│ r' - 'temperature'","type":"invalid_ │                                      │                                      │
│ request_error","param":null,"code":n │                                      │                                      │
│ ull}}     
```

Same for OPENAI_MAX_TOKENS. I tested the code path in lines 221-22 but I'm not sure how it to trigger the lines 140-41 code path.