### PR TITLE
Add support for OpenAI functions and custom provider args

### DIFF
--- a/examples/openai-function-call/.prettierignore
+++ b/examples/openai-function-call/.prettierignore
@@ -1,0 +1,1 @@
+promptfooconfig.yaml

--- a/examples/openai-function-call/.prettierignore
+++ b/examples/openai-function-call/.prettierignore
@@ -1,1 +1,0 @@
-promptfooconfig.yaml

--- a/examples/openai-function-call/README.md
+++ b/examples/openai-function-call/README.md
@@ -1,0 +1,5 @@
+This example is pre-configured in `promptfooconfig.yaml`. That means you can just run:
+
+```
+promptfoo eval
+```

--- a/examples/openai-function-call/output.csv
+++ b/examples/openai-function-call/output.csv
@@ -1,0 +1,7 @@
+"[
+  {""role"": ""user"", ""content"": ""What is the weather like in {{city}}?""}
+]",city
+"[PASS] {""name"":""get_current_weather"",""arguments"":""{\n  \""location\"": \""Boston, MA\""\n}""}",Boston
+"[PASS] {""name"":""get_current_weather"",""arguments"":""{\n  \""location\"": \""New York\""\n}""}",New York
+"[PASS] {""name"":""get_current_weather"",""arguments"":""{\n  \""location\"": \""Paris\""\n}""}",Paris
+"[PASS] {""name"":""get_current_weather"",""arguments"":""{\n  \""location\"": \""Mars\""\n}""}",Mars

--- a/examples/openai-function-call/prompt.txt
+++ b/examples/openai-function-call/prompt.txt
@@ -1,0 +1,3 @@
+[
+  {"role": "user", "content": "What is the weather like in {{city}}?"}
+]

--- a/examples/openai-function-call/promptfooconfig.yaml
+++ b/examples/openai-function-call/promptfooconfig.yaml
@@ -1,0 +1,35 @@
+prompts: [prompt.txt]
+providers:
+  - 'openai:chat:gpt-3.5-turbo-0613':
+      config:
+        "functions": [
+          {
+            "name": "get_current_weather",
+            "description": "Get the current weather in a given location",
+            "parameters": {
+              "type": "object",
+              "properties": {
+                "location": {
+                  "type": "string",
+                  "description": "The city and state, e.g. San Francisco, CA"
+                },
+                "unit": {
+                  "type": "string",
+                  "enum": ["celsius", "fahrenheit"]
+                }
+              },
+              "required": ["location"]
+            }
+          }
+        ]
+
+outputPath: output.csv
+tests:
+  - vars:
+      city: Boston
+  - vars:
+      city: New York
+  - vars:
+      city: Paris
+  - vars:
+      city: Mars

--- a/examples/openai-function-call/promptfooconfig.yaml
+++ b/examples/openai-function-call/promptfooconfig.yaml
@@ -1,3 +1,4 @@
+# prettier-ignore
 prompts: [prompt.txt]
 providers:
   - 'openai:chat:gpt-3.5-turbo-0613':

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -77,7 +77,7 @@ export async function fetchJsonWithCache(
   try {
     const data = await response.json();
     if (response.ok) {
-      logger.debug(`Storing ${url} response in cache: ${data}`);
+      logger.debug(`Storing ${url} response in cache: ${JSON.stringify(data)}`);
       await cache.set(cacheKey, JSON.stringify(data));
     }
     return {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -24,9 +24,11 @@ const customFormatter = winston.format.printf(({ level, message, ...args }) => {
 const logger = winston.createLogger({
   levels: LOG_LEVELS,
   format: winston.format.combine(winston.format.simple(), customFormatter),
-  transports: [new winston.transports.Console({
-    level: process.env.LOG_LEVEL || 'info',
-  })],
+  transports: [
+    new winston.transports.Console({
+      level: process.env.LOG_LEVEL || 'info',
+    }),
+  ],
 });
 
 export function getLogLevel() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 
 import telemetry from './telemetry';
-import logger, { setLogLevel } from './logger';
+import logger, { getLogLevel, setLogLevel } from './logger';
 import { loadApiProvider, loadApiProviders } from './providers';
 import { evaluate } from './evaluator';
 import {
@@ -123,10 +123,9 @@ async function main() {
     .command('eval')
     .description('Evaluate prompts')
     .requiredOption('-p, --prompts <paths...>', 'Paths to prompt files (.txt)', config.prompts)
-    .requiredOption(
+    .option(
       '-r, --providers <name or path...>',
       'One of: openai:chat, openai:completion, openai:<model name>, or path to custom API caller module',
-      config?.providers,
     )
     .option(
       '-c, --config <path>',
@@ -243,7 +242,7 @@ async function main() {
       };
 
       const options: EvaluateOptions = {
-        showProgressBar: true,
+        showProgressBar: getLogLevel() !== 'debug',
         maxConcurrency: !isNaN(maxConcurrency) && maxConcurrency > 0 ? maxConcurrency : undefined,
         ...evaluateOptions,
       };
@@ -261,7 +260,7 @@ async function main() {
       if (cmdObj.output) {
         logger.info(chalk.yellow(`Writing output to ${cmdObj.output}`));
         writeOutput(cmdObj.output, summary);
-      } else {
+      } else if (getLogLevel() !== 'debug') {
         // Output table by default
         const maxWidth = process.stdout.columns ? process.stdout.columns - 10 : 120;
         const head = summary.table.head;

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,11 @@ export interface CommandLineOptions {
   promptSuffix?: string;
 }
 
+export interface ProviderConfig {
+  id: ProviderId;
+  config?: any;
+}
+
 export interface ApiProvider {
   id: () => string;
   callApi: (prompt: string) => Promise<ProviderResponse>;
@@ -187,13 +192,17 @@ export interface TestSuite {
   defaultTest?: Partial<TestCase>;
 }
 
+export type ProviderId = string;
+
+export type RawProviderConfig = Record<ProviderId, Omit<ProviderConfig, 'id'>>;
+
 // TestSuiteConfig = Test Suite, but before everything is parsed and resolved.  Providers are just strings, prompts are filepaths, tests can be filepath or inline.
 export interface TestSuiteConfig {
   // Optional description of what your LLM is trying to do
   description?: string;
 
   // One or more LLM APIs to use, for example: openai:gpt-3.5-turbo, openai:gpt-4, localai:chat:vicuna
-  providers: string | string[];
+  providers: ProviderId | ProviderId[] | RawProviderConfig[];
 
   // One or more prompt files to load
   prompts: string | string[];

--- a/test/providers.test.ts
+++ b/test/providers.test.ts
@@ -3,7 +3,8 @@ import fetch from 'node-fetch';
 import { OpenAiCompletionProvider, OpenAiChatCompletionProvider } from '../src/providers/openai';
 
 import { disableCache, enableCache } from '../src/cache.js';
-import { loadApiProvider } from '../src/providers.js';
+import { loadApiProvider, loadApiProviders } from '../src/providers.js';
+import type { RawProviderConfig } from '../src/types';
 
 jest.mock('node-fetch', () => jest.fn());
 
@@ -87,5 +88,35 @@ describe('providers', () => {
   test('loadApiProvider with openai:completion:modelName', async () => {
     const provider = await loadApiProvider('openai:completion:text-davinci-003');
     expect(provider).toBeInstanceOf(OpenAiCompletionProvider);
+  });
+
+  test('loadApiProvider with RawProviderConfig', async () => {
+    const rawProviderConfig = {
+      'openai:chat': {
+        id: 'test',
+        config: { foo: 'bar' },
+      },
+    };
+    const provider = await loadApiProvider('openai:chat', rawProviderConfig['openai:chat']);
+    expect(provider).toBeInstanceOf(OpenAiChatCompletionProvider);
+  });
+
+  test('loadApiProviders with RawProviderConfig[]', async () => {
+    const rawProviderConfigs: RawProviderConfig[] = [
+      {
+        'openai:chat:abc123': {
+          config: { foo: 'bar' },
+        },
+      },
+      {
+        'openai:completion:def456': {
+          config: { foo: 'bar' },
+        },
+      },
+    ];
+    const providers = await loadApiProviders(rawProviderConfigs);
+    expect(providers).toHaveLength(2);
+    expect(providers[0]).toBeInstanceOf(OpenAiChatCompletionProvider);
+    expect(providers[1]).toBeInstanceOf(OpenAiCompletionProvider);
   });
 });


### PR DESCRIPTION
- Add support for OpenAI ChatCompletion function calls
- logger respects LOG_LEVEL envar
- Add support for OpenAI functions and custom provider args

Basically allows you to stuff whatever options you want inside a `config` key in a provider. Config format looks like this, for example:
```yaml
prompts: [prompt.txt]
providers:
  - 'openai:chat:gpt-3.5-turbo-0613':
      config:
        "functions": [
          {
            "name": "get_current_weather",
            "description": "Get the current weather in a given location",
            "parameters": {
              "type": "object",
              "properties": {
                "location": {
                  "type": "string",
                  "description": "The city and state, e.g. San Francisco, CA"
                },
                "unit": {
                  "type": "string",
                  "enum": ["celsius", "fahrenheit"]
                }
              },
              "required": ["location"]
            }
          }
        ]

outputPath: output.csv
tests:
  - vars:
      city: Boston
  - vars:
      city: New York
  - vars:
      city: Paris
  - vars:
      city: Mars
```