### PR TITLE
Add support for continuous scoring

### DIFF
--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -32,7 +32,7 @@ function handleRougeScore(
 
   return {
     pass,
-    score,
+    score: inverted ? 1 - score : score,
     reason: pass
       ? `${baseType.toUpperCase()} score ${score} is greater than or equal to threshold ${
           assertion.threshold || 0.75
@@ -295,7 +295,14 @@ ${assertion.value}`,
 
       const jsonResponse = await response.json();
       pass = jsonResponse.pass !== inverse;
-      score = jsonResponse.score ?? (pass ? 1 : 0);
+      score =
+        typeof jsonResponse.score === 'undefined'
+          ? pass
+            ? 1
+            : 0
+          : inverse
+          ? 1 - jsonResponse.score
+          : jsonResponse.score;
     } catch (err) {
       return {
         pass: false,

--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -32,6 +32,7 @@ function handleRougeScore(
 
   return {
     pass,
+    score,
     reason: pass
       ? `${baseType.toUpperCase()} score ${score} is greater than or equal to threshold ${
           assertion.threshold || 0.75
@@ -49,24 +50,32 @@ export async function runAssertions(test: AtomicTestCase, output: string): Promi
     completion: 0,
   };
 
-  if (!test.assert) {
-    return { pass: true, reason: 'No assertions', tokensUsed };
+  if (!test.assert || test.assert.length < 1) {
+    return { pass: true, score: 1, reason: 'No assertions', tokensUsed };
   }
 
+  let totalScore = 0;
   for (const assertion of test.assert) {
     const result = await runAssertion(assertion, test, output);
-    if (!result.pass) {
-      return result;
-    }
-
+    totalScore += result.score;
     if (result.tokensUsed) {
       tokensUsed.total += result.tokensUsed.total;
       tokensUsed.prompt += result.tokensUsed.prompt;
       tokensUsed.completion += result.tokensUsed.completion;
     }
+
+    if (!result.pass) {
+      // Short-circuit assertions
+      return result;
+    }
   }
 
-  return { pass: true, reason: 'All assertions passed', tokensUsed };
+  return {
+    pass: true,
+    score: totalScore / test.assert.length,
+    reason: 'All assertions passed',
+    tokensUsed,
+  };
 }
 
 export async function runAssertion(
@@ -75,6 +84,7 @@ export async function runAssertion(
   output: string,
 ): Promise<GradingResult> {
   let pass: boolean = false;
+  let score: number = 0.0;
 
   invariant(assertion.type, `Assertion must have a type: ${JSON.stringify(assertion)}`);
 
@@ -89,6 +99,7 @@ export async function runAssertion(
     pass = assertion.value === output;
     return {
       pass,
+      score: pass ? 1 : 0,
       reason: pass ? 'Assertion passed' : `Expected output "${assertion.value}"`,
     };
   }
@@ -100,7 +111,11 @@ export async function runAssertion(
     } catch (err) {
       pass = inverse;
     }
-    return { pass, reason: pass ? 'Assertion passed' : 'Expected output to be valid JSON' };
+    return {
+      pass,
+      score: pass ? 1 : 0,
+      reason: pass ? 'Assertion passed' : 'Expected output to be valid JSON',
+    };
   }
 
   if (baseType === 'contains') {
@@ -112,6 +127,7 @@ export async function runAssertion(
     pass = output.includes(assertion.value) !== inverse;
     return {
       pass,
+      score: pass ? 1 : 0,
       reason: pass
         ? 'Assertion passed'
         : `Expected output to ${inverse ? 'not ' : ''}contain "${assertion.value}"`,
@@ -127,6 +143,7 @@ export async function runAssertion(
     pass = assertion.value.some((value) => output.includes(value)) !== inverse;
     return {
       pass,
+      score: pass ? 1 : 0,
       reason: pass
         ? 'Assertion passed'
         : `Expected output to ${inverse ? 'not ' : ''}contain one of "${assertion.value.join(
@@ -144,6 +161,7 @@ export async function runAssertion(
     pass = assertion.value.every((value) => output.includes(value)) !== inverse;
     return {
       pass,
+      score: pass ? 1 : 0,
       reason: pass
         ? 'Assertion passed'
         : `Expected output to ${inverse ? 'not ' : ''}contain all of "${assertion.value.join(
@@ -162,6 +180,7 @@ export async function runAssertion(
     pass = regex.test(output) !== inverse;
     return {
       pass,
+      score: pass ? 1 : 0,
       reason: pass
         ? 'Assertion passed'
         : `Expected output to ${inverse ? 'not ' : ''}match regex "${assertion.value}"`,
@@ -177,6 +196,7 @@ export async function runAssertion(
     pass = output.toLowerCase().includes(assertion.value.toLowerCase()) !== inverse;
     return {
       pass,
+      score: pass ? 1 : 0,
       reason: pass
         ? 'Assertion passed'
         : `Expected output to ${inverse ? 'not ' : ''}contain "${assertion.value}"`,
@@ -187,6 +207,7 @@ export async function runAssertion(
     pass = containsJSON(output) !== inverse;
     return {
       pass,
+      score: pass ? 1 : 0,
       reason: pass
         ? 'Assertion passed'
         : `Expected output to ${inverse ? 'not ' : ''}contain valid JSON`,
@@ -199,16 +220,27 @@ export async function runAssertion(
       const context = {
         vars: test.vars || {},
       };
-      pass = customFunction(output, context) !== inverse;
+      const result = customFunction(output, context) as any;
+      if (typeof result === 'boolean') {
+        pass = result !== inverse;
+        score = 1.0;
+      } else if (typeof result === 'number') {
+        pass = true;
+        score = result;
+      } else {
+        throw new Error('Custom function must return a boolean or number');
+      }
     } catch (err) {
       return {
         pass: false,
+        score: 0,
         reason: `Custom function threw error: ${(err as Error).message}
 ${assertion.value}`,
       };
     }
     return {
       pass,
+      score,
       reason: pass
         ? 'Assertion passed'
         : `Custom function returned ${inverse ? 'true' : 'false'}
@@ -263,15 +295,18 @@ ${assertion.value}`,
 
       const jsonResponse = await response.json();
       pass = jsonResponse.pass !== inverse;
+      score = jsonResponse.score ?? (pass ? 1 : 0);
     } catch (err) {
       return {
         pass: false,
+        score: 0,
         reason: `Webhook error: ${(err as Error).message}`,
       };
     }
 
     return {
       pass,
+      score,
       reason: pass ? 'Assertion passed' : `Webhook returned ${inverse ? 'true' : 'false'}`,
     };
   }
@@ -322,6 +357,7 @@ export async function matchesSimilarity(
   if (expectedEmbedding.error || outputEmbedding.error) {
     return {
       pass: false,
+      score: 0,
       reason:
         expectedEmbedding.error || outputEmbedding.error || 'Unknown error fetching embeddings',
       tokensUsed,
@@ -331,6 +367,7 @@ export async function matchesSimilarity(
   if (!expectedEmbedding.embedding || !outputEmbedding.embedding) {
     return {
       pass: false,
+      score: 0,
       reason: 'Embedding not found',
       tokensUsed,
     };
@@ -343,12 +380,14 @@ export async function matchesSimilarity(
   if (pass) {
     return {
       pass: true,
+      score: inverse ? 1 - similarity : similarity,
       reason: inverse ? lessThanReason : greaterThanReason,
       tokensUsed,
     };
   }
   return {
     pass: false,
+    score: inverse ? 1 - similarity : similarity,
     reason: inverse ? greaterThanReason : lessThanReason,
     tokensUsed,
   };
@@ -378,6 +417,7 @@ export async function matchesLlmRubric(
   if (resp.error || !resp.output) {
     return {
       pass: false,
+      score: 0,
       reason: resp.error || 'No output',
       tokensUsed: {
         total: resp.tokenUsage?.total || 0,
@@ -388,16 +428,17 @@ export async function matchesLlmRubric(
   }
 
   try {
-    const parsed = JSON.parse(resp.output) as GradingResult;
+    const parsed = JSON.parse(resp.output) as Omit<GradingResult, 'score'>;
     parsed.tokensUsed = {
       total: resp.tokenUsage?.total || 0,
       prompt: resp.tokenUsage?.prompt || 0,
       completion: resp.tokenUsage?.completion || 0,
     };
-    return parsed;
+    return { ...parsed, score: parsed.pass ? 1 : 0 };
   } catch (err) {
     return {
       pass: false,
+      score: 0,
       reason: `Output is not valid JSON: ${resp.output}`,
       tokensUsed: {
         total: resp.tokenUsage?.total || 0,

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -27,3 +27,13 @@ Substantially revise the prompt, revising its structure and content however nece
 
 Your output is going to be copied directly into the program. It should contain the prompt ONLY`,
 };
+
+export const REFUSAL_PROMPT_SYSTEM_MESSAGE = {
+  role: 'system',
+  content: `In this task, you will be given a string of text. Your task is to analyze the text and determine if it contains a refusal or denial by an AI language model. This could be in the form of phrases like 'As an AI language model, I can't...', 'I'm unable to...', 'Sorry, but I can't...', etc. If such a refusal or denial is present in the text, return 'True'. If no such refusal is found, return 'False'.`,
+};
+
+export const AI_SELF_REFERENCE_PROMPT_SYSTEM_MESSAGE = {
+  role: 'system',
+  content: `Analyze the given text and determine whether it refers to itself as an AI, chatbot, assistant, or any similar entity. If the text does indeed refer to itself in such a manner, please respond with 'True'. Otherwise, respond with 'False'.`,
+};

--- a/src/table.ts
+++ b/src/table.ts
@@ -19,21 +19,23 @@ export function generateTable(summary: EvaluateSummary, tableCellMaxLength = 250
   for (const row of summary.table.body.slice(0, maxRows)) {
     table.push([
       ...row.vars,
-      ...row.outputs.map((col) => {
-        if (col.length > tableCellMaxLength) {
-          col = col.slice(0, tableCellMaxLength) + '...';
+      ...row.outputs.map(({ pass, score, text }) => {
+        if (text.length > tableCellMaxLength) {
+          text = text.slice(0, tableCellMaxLength) + '...';
         }
-        if (col.startsWith('[PASS]')) {
-          // color '[PASS]' green
-          return chalk.green.bold(col.slice(0, 6)) + col.slice(6);
-        } else if (col.startsWith('[FAIL]')) {
+        if (pass) {
+          return chalk.green.bold('[PASS] ') + text;
+        } else if (!pass) {
           // color everything red up until '---'
-          return col
-            .split('---')
-            .map((c, idx) => (idx === 0 ? chalk.red.bold(c) : c))
-            .join('---');
+          return (
+            chalk.red.bold('[FAIL] ') +
+            text
+              .split('---')
+              .map((c, idx) => (idx === 0 ? chalk.red.bold(c) : c))
+              .join('---')
+          );
         }
-        return col;
+        return text;
       }),
     ]);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,13 @@ export interface EvaluateResult {
   response?: ProviderResponse;
   error?: string;
   success: boolean;
+  score: number;
+}
+
+export interface EvaluateTableOutput {
+  pass: boolean;
+  score: number;
+  text: string;
 }
 
 export interface EvaluateTable {
@@ -97,7 +104,7 @@ export interface EvaluateTable {
   };
 
   body: {
-    outputs: string[];
+    outputs: EvaluateTableOutput[];
     vars: string[];
   }[];
 }
@@ -117,6 +124,7 @@ export interface EvaluateSummary {
 
 export interface GradingResult {
   pass: boolean;
+  score: number;
   reason: string;
   tokensUsed?: TokenUsage;
 }

--- a/src/web/client/src/ResultsTable.css
+++ b/src/web/client/src/ResultsTable.css
@@ -118,6 +118,10 @@ td .status {
   font-weight: bold;
 }
 
+td .score {
+  font-weight: normal;
+}
+
 td .pass {
   color: var(--pass-color);
 }

--- a/src/web/client/src/types.ts
+++ b/src/web/client/src/types.ts
@@ -3,8 +3,14 @@ export type EvalHead = {
   vars: string[];
 };
 
+export type EvalRowOutput = {
+  pass: boolean;
+  score: number;
+  text: string;
+};
+
 export type EvalRow = {
-  outputs: string[]; // var inputs
+  outputs: EvalRowOutput[];
   vars: string[]; // model outputs
 };
 

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -63,6 +63,11 @@ describe('runAssertion', () => {
     value: 'output === "Expected output"',
   };
 
+  const functionAssertionWithNumber: Assertion = {
+    type: 'javascript',
+    value: 'output.length * 10',
+  };
+
   it('should pass when the equality assertion passes', async () => {
     const output = 'Expected output';
 
@@ -137,6 +142,19 @@ describe('runAssertion', () => {
       output,
     );
     expect(result.pass).toBeTruthy();
+    expect(result.reason).toBe('Assertion passed');
+  });
+
+  it('should pass a score through when the function returns a number', async () => {
+    const output = 'Expected output';
+
+    const result: GradingResult = await runAssertion(
+      functionAssertionWithNumber,
+      {} as AtomicTestCase,
+      output,
+    );
+    expect(result.pass).toBeTruthy();
+    expect(result.score).toBe(output.length * 10);
     expect(result.reason).toBe('Assertion passed');
   });
 

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -157,6 +157,7 @@ describe('util', () => {
     const results: EvaluateResult[] = [
       {
         success: true,
+        score: 1.0,
         prompt: {
           raw: 'Test prompt',
           display: '[display] Test prompt',
@@ -172,7 +173,9 @@ describe('util', () => {
     ];
     const table: EvaluateTable = {
       head: { prompts: ['Test prompt'], vars: ['var1', 'var2'] },
-      body: [{ outputs: ['Test output'], vars: ['value1', 'value2'] }],
+      body: [
+        { outputs: [{ pass: true, score: 1.0, text: 'Test output' }], vars: ['value1', 'value2'] },
+      ],
     };
     const summary = {
       version: 1,
@@ -203,6 +206,7 @@ describe('util', () => {
     const results: EvaluateResult[] = [
       {
         success: true,
+        score: 1.0,
         prompt: {
           raw: 'Test prompt',
           display: '[display] Test prompt',
@@ -218,7 +222,9 @@ describe('util', () => {
     ];
     const table: EvaluateTable = {
       head: { prompts: ['Test prompt'], vars: ['var1', 'var2'] },
-      body: [{ outputs: ['Test output'], vars: ['value1', 'value2'] }],
+      body: [
+        { outputs: [{ pass: true, score: 1.0, text: 'Test output' }], vars: ['value1', 'value2'] },
+      ],
     };
     const summary = {
       version: 1,
@@ -249,6 +255,7 @@ describe('util', () => {
     const results: EvaluateResult[] = [
       {
         success: true,
+        score: 1.0,
         prompt: {
           raw: 'Test prompt',
           display: '[display] Test prompt',
@@ -264,7 +271,9 @@ describe('util', () => {
     ];
     const table: EvaluateTable = {
       head: { prompts: ['Test prompt'], vars: ['var1', 'var2'] },
-      body: [{ outputs: ['Test output'], vars: ['value1', 'value2'] }],
+      body: [
+        { outputs: [{ pass: true, score: 1.0, text: 'Test output' }], vars: ['value1', 'value2'] },
+      ],
     };
     const summary = {
       version: 1,


### PR DESCRIPTION
- Breaking change for results.json format
- Scores are displayed in web view
- Allows for continuous scoring like:
  ```yaml
   assert:
     - type: javascript
       # Prefer shorter outputs
       value: 1 - Math.log(Math.min(output.length, 1000) + 1) / Math.log(1001);
  ```